### PR TITLE
 Fix improper argument serialization on ARGV passing tecnique ( alvarezp )

### DIFF
--- a/Readme
+++ b/Readme
@@ -164,6 +164,11 @@ To use forking mechanism on Unix , you need tclx extension.
 
 ciscocmd will try to load Tclx extension automatically
 
+Development url:
+----------------
+
+https://github.com/eczema/ciscocmd-cosi/
+
 Final Word:
 -----------
 

--- a/ciscocmd
+++ b/ciscocmd
@@ -75,7 +75,7 @@
 # New way to load tclx without specify the path :-)
 
 # The next line store the args in memory \
-IFS='µ' ; export ARGS=$@
+IFS='Âµ' ; export ARGS="$*"
 # the next line restarts using expect \
 exec expect  -- "$0" 
 
@@ -85,7 +85,7 @@ log_user 0
 # first: take arguments from environment variable
 
 regsub -all -- "{|}" [lrange [array get env ARGS] 1 end] "" argv
-regsub -all -- "µ" $argv "\" \"" argv
+regsub -all -- "Âµ" $argv "\" \"" argv
 regsub -all -- "^|$" $argv "\"" argv
 
 if { $argv == "" || $argv == "\""} {


### PR DESCRIPTION
ciscocmd uses a tecnique to pass arguments to expect by means of
serialization. The tecnique incorrectly used IFS combined with $@
instead of "$*".

This worked on Bash 4.3 because of a bug that was fixed on 4.4,
which breaks the tecnique.

This fixes the usage and restores ciscocmd functionality on Bash 4.4.

This fixes issue #2 on Github:


