### PR TITLE
Add support for Y/N prompts and crypto certificate import

### DIFF
--- a/ciscocmd
+++ b/ciscocmd
@@ -358,7 +358,7 @@ proc waitprompt {} {
 				if { $nl > 20 } { send "" ; set nl 0 }
 				if { $continuousprompt == "0" } { exp_continue }
 			}
-			-re "enable\\) \*$|> *\*$|admin:\\**\*$|assword: \*$|\\$ \*$|ser(name)?: \*$|confirm\]\*$|y/n\] :\*$|\\? *\*$" {
+			-re "enable\\) \*$|> *\*$|admin:\\**\*$|assword: \*$|\\$ \*$|ser(name)?: \*$|confirm\]\*$|y/n\] :\*$|\\(Y/N\\).*(\\?| )|\\? \[Y/N\]|\\? *\*$" {
 				set continuousprompt "0"
 				if   { [ info exist logfd  ] && $logger == 1 } {
 					regsub -all -- "" $expect_out(buffer) "" add

--- a/ciscocmd
+++ b/ciscocmd
@@ -346,8 +346,11 @@ proc waitprompt {} {
 				disconnect
 				exit 1
 			}
-			-re "Enter TEXT message." {
+			-re "Enter TEXT message.| add a period.*$" {
 				set continuousprompt "1"
+			}
+			-re "successfully$" {
+				set continuousprompt "0"
 			}
 			-re "\n" {
                        		if   { [ info exist logfd  ] && $logger == 1 }  {
@@ -518,19 +521,19 @@ foreach host $hostlist {
 				expect -re "assword"
 				global password
 				varcheck "password" 1
-				send  "$password\r"
+				send -- "$password\r"
 				}
         	"ser"	{
                 	        varcheck "username" 0
-                	        send  "$username\r"
+                	        send -- "$username\r"
                 	        expect -re "assword"
                 	        global password
                 	        varcheck "password" 1
-                	        send  "$password\r"
+                	        send -- "$password\r"
                 	        }
        		"assword"       {
                 	        varcheck "password" 1
-                        	send  "$password\r"
+                        	send -- "$password\r"
                         	}
         	default         {
                 	        exit
@@ -550,18 +553,18 @@ foreach host $hostlist {
 				send "\n"
 				}
 			"assword" {
-				send  "$secretpassword\r"
+				send -- "$secretpassword\r"
 				}
 		}
 	#	expect -re "assword"
-	#	send  "$secretpassword\r"
+	#	send -- "$secretpassword\r"
 		waitprompt
 	}
 
-	if [ catch { send  "$termlen\r" } ] {send_user "$host failed to connect\n" ; exit }  
+	if [ catch { send -- "$termlen\r" } ] {send_user "$host failed to connect\n" ; exit }
 	waitprompt
 	if { $termwidth != "" } {
-		send "$termwidth $width\r"
+		send -- "$termwidth $width\r"
 		waitprompt
 	}
 
@@ -597,14 +600,15 @@ foreach host $hostlist {
 		set cmdlist [open $cmdfile "r" ]
 		while {[eof $cmdlist] == 0} {
 			set command [gets $cmdlist]
-			send "$command\r"
+			if { $command == "." } { set continuousprompt "0" }
+			send -- "$command\r"
 			waitprompt
 		}
 	} else {
 		varcheck command 0
                 if [ catch { send "\r" } ] { continue }
                 if [ catch { waitprompt } ] { continue }
-                if [ catch { send "$command\r" } ]  { continue }
+                if [ catch { send -- "$command\r" } ]  { continue }
                 if [ catch { waitprompt } ] { continue }
 	}
 	


### PR DESCRIPTION
These two commits add support for Y/N prompts and the `crypto certificate import command` in the Small Business switches in the SG250, SG350, and SG550XG series.

The Y/N prompts on these systems differ slightly from the prompts detected by the existing regex. For example, the `copy running-config startup-config` and the `delete` commands both require confirmation.  The exact prompts observed are quoted in the commit log; the documentation for `delete` in the [Command Line Reference Guide](https://www.cisco.com/c/dam/en/us/td/docs/switches/lan/csbms/550xseries/2_4_5/cli_guide/cli_sx550x_sg550xg_2_4_5.pdf) suggests yet another possible variation.  I'm not sure what the `^G` characters mean in your regex; guidance on tailoring the regex would be appreciated.

The `crypto certificate import` command also needs special treatment, to send a PEM-encoded certificate that is terminated by a line with a single `.`.  Again, the observed wording of the "Please paste the input now, add a period (.) on a separate line after the input" prompt differs from the documentation, in that the documentation also says ",and press Enter.".

The certificate import patch also fixes a bug with calls to `send`, where user-supplied text could be misinterpreted as a flag by the `send` procedure.